### PR TITLE
Release v5.4.8 + v5.5.0 — winget warnings + skip granular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.8] - 2026-05-08
+
+Discovered via v5.4.7 dry-run audit on `setup.sh --dry-run --unattended -y full`.
+macOS dispatcher emitted `WARN Unknown package file: winget-developer.txt`
+and the same for `winget-full.txt`. Asymmetric with Linux (which handles
+all brew-cask-* variants in one branch).
+
+### Fixed
+- **`macos/main.sh`: silence `winget-developer.txt` and `winget-full.txt`**
+  as Windows-only, same as `winget.txt`. The case branch now matches
+  all three files.
+
+### Added (tests)
+- 1 regression test (`v5.4.8`) in `tests/test-regressions.bats`:
+  macos dispatcher pattern (all winget-*.txt covered). Suite: 24/24 OK.
+
 ## [5.4.7] - 2026-05-07
 
 Closes the last orchestrator that was still under wave-level retry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.0] - 2026-05-08
+
+Skip granular: closes Deney's wishlist ("se ja fez partes anteriores
+tem que ter algo para pular mais facil"). The `setup.sh` post-install
+prompts (dotfiles, terminal blueprint) are now gated on per-section
+state. Re-running `setup.sh` after a successful previous run silently
+skips sections that already completed, instead of asking again.
+
+This is a **MINOR** version bump because the menu shape of
+`detect_previous_install` changed (3 options -> 4 options), which
+is user-visible behavior even though no flag/API broke.
+
+### Added
+- **Section state helpers** in `src/core/progress.sh`:
+  - `mark_section_done <name>` — idempotent append to state file
+  - `is_section_done <name>` — 0/1 check
+  - `list_sections_done` — echo space-separated list
+  - `clear_sections_done` — reset sections line only
+
+  State file gains a new optional line `sections_done=...`. Existing
+  state files without the line continue to work; helpers create the
+  line on first call.
+
+- **`setup.sh` section gating**: dotfiles and terminal-blueprint
+  prompts are skipped (with informative `log_info`) when the section
+  is marked done. After a successful run of either, the section is
+  marked. No behavior change in `--unattended` mode (which never ran
+  these prompts to begin with).
+
+- **`detect_previous_install` 4-option menu**:
+  ```
+  1) Continue (skip sections marked done: <list>)
+  2) Reinstall everything (re-run all sections regardless of state)
+  3) Fresh install (clear state, start over)
+  4) Cancel
+  ```
+  Default = 1. Option 2 calls `clear_sections_done`, option 3 deletes
+  the state file. The prompt always surfaces `[1-4, default=1]`,
+  consistent with v5.4.0/v5.4.4/v5.4.6 default-surfacing convention.
+
+### Fixed
+- **`save_install_state` no longer clobbers `sections_done`**.
+  Previous version emitted only the 4 metadata fields, so any
+  `sections_done` line written by `mark_section_done` was wiped on
+  the next save (the final save at end of `setup.sh`). Regression
+  test added.
+
+### Added (tests)
+- 8 bats regression tests (`v5.5.0`) in `tests/test-regressions.bats`:
+  helper behavior, idempotency, multi-section, clear/preserve,
+  state file integrity across saves, menu shape, setup.sh wiring.
+
+- 3 Pester behavior scaffolds (Skip gate) in `tests/pester/winget.Tests.ps1`:
+  template tests for Windows CI runner. Documents the `winget.ps1`
+  refactor required (extract to `.psm1` module + thin runner) before
+  tests can flip from Skip to active.
+
+### Docs
+- `CONTRIBUTING.md`: admin policy section — PRs over branch-protection
+  bypass. Default release flow now documented as PR-based.
+- `docs/REFACTOR-SELECTORS.md`: planning document for unifying the
+  three selection mechanisms (`wizard.sh`, `interactive.sh`,
+  `group-selector.sh`) into `src/core/select.sh`. Marked v5.6.0+.
+
 ## [5.4.8] - 2026-05-08
 
 Discovered via v5.4.7 dry-run audit on `setup.sh --dry-run --unattended -y full`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,6 +264,26 @@ This project uses GitHub Flow.
 - All changes go through pull requests -- direct pushes to `main` are not accepted
 - There is no `develop`, `next`, or `staging` branch
 
+### Admin policy: PRs over bypass
+
+Maintainers with admin permission can bypass branch protection. **Don't.**
+The protection (PR required + signed commits) exists for review and
+provenance. Releases v5.4.4–v5.4.7 were pushed via admin bypass under
+time pressure; future releases should go through the PR flow even when
+the change feels "obviously safe."
+
+If a release truly requires bypass (incident hotfix), document the
+reason in the commit body so the bypass is auditable. Otherwise prefer:
+
+```bash
+git checkout -b release/v5.x.y
+# ... commits ...
+git push -u origin release/v5.x.y
+gh pr create --fill
+gh pr merge --squash --delete-branch
+git tag v5.x.y && git push origin v5.x.y
+```
+
 ## Pull Request Process
 
 1. Fork the repository and create a feature branch from `main`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
 
-[![Version: 5.4.7](https://img.shields.io/badge/Version-5.4.7-orange?style=flat)](CHANGELOG.md)
+[![Version: 5.4.8](https://img.shields.io/badge/Version-5.4.8-orange?style=flat)](CHANGELOG.md)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat)](LICENSE)
 [![Platforms: Linux | macOS | Windows](https://img.shields.io/badge/Platforms-Linux%20%7C%20macOS%20%7C%20Windows-informational?style=flat)](README.md)
 [![Shell: Bash 4.0+](https://img.shields.io/badge/Shell-Bash%204.0%2B-4EAA25?style=flat&logo=gnu-bash&logoColor=white)](https://www.gnu.org/software/bash/)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
 
-[![Version: 5.4.8](https://img.shields.io/badge/Version-5.4.8-orange?style=flat)](CHANGELOG.md)
+[![Version: 5.5.0](https://img.shields.io/badge/Version-5.5.0-orange?style=flat)](CHANGELOG.md)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat)](LICENSE)
 [![Platforms: Linux | macOS | Windows](https://img.shields.io/badge/Platforms-Linux%20%7C%20macOS%20%7C%20Windows-informational?style=flat)](README.md)
 [![Shell: Bash 4.0+](https://img.shields.io/badge/Shell-Bash%204.0%2B-4EAA25?style=flat&logo=gnu-bash&logoColor=white)](https://www.gnu.org/software/bash/)

--- a/docs/REFACTOR-SELECTORS.md
+++ b/docs/REFACTOR-SELECTORS.md
@@ -1,0 +1,101 @@
+# Refactor: Unified Selection Mechanism
+
+> **Status**: Planned for v5.6.0+
+> **Estimated cost**: 2-3 days dedicated work
+> **Created**: 2026-05-08 (during ultrathink audit pre-v5.5.0)
+
+## Problem
+
+Three independent selection mechanisms exist in the codebase, each with
+its own UX conventions and bug surface area:
+
+| Mechanism | File | Used for |
+|-----------|------|----------|
+| `select_profile_interactive` | `src/core/wizard.sh` | First-run profile picker (minimal/developer/full) |
+| `show_category_menu` + `ask_tool` | `src/core/interactive.sh` | Per-category dev-env opt-in (Node/Python/mise) |
+| `select_groups` (gum + bash fallback) | `src/core/group-selector.sh` | Cask groups multi-select |
+
+### Pain caused by fragmentation
+
+1. **Bug fixes don't propagate.** v5.4.0 fixed a default-inversion in
+   `show_category_menu`, v5.4.4 fixed the same class in
+   `detect_previous_install`, v5.4.6 fixed it in `ai-tools` and
+   `group-selector`. Same bug, four fixes, because each prompt was
+   coded independently.
+2. **UX inconsistency.** Some prompts say `[default=N]`, others put
+   default in case fallthrough silently, others use timeout-based
+   defaults (`interactive.sh:40`). User has no muscle memory.
+3. **Adding new selection requires choice.** "Where should this new
+   prompt live?" — every contributor has to re-derive the answer.
+4. **Testing duplication.** Each mechanism gets its own set of
+   regression tests (see test-regressions.bats v5.4.0 / v5.4.4 /
+   v5.4.6 entries).
+
+## Proposed shape
+
+Single abstraction in `src/core/select.sh`:
+
+```bash
+# select_one - prompt user to choose one of N labeled options
+# Args: $1 = prompt, $2 = default_index (1-based), rest = labels
+# Returns: 0, echoes selected label name to stdout
+# Honours: NONINTERACTIVE=true → echoes default and returns 0
+# UX contract: prompt always shows "[1-N, default=K]" inline
+select_one() { ... }
+
+# select_multi - prompt user to multi-select from N labeled options
+# Args: $1 = prompt, rest = labels
+# Returns: 0, echoes one label per line on stdout
+# Renders: gum choose --no-limit if available, bash numbered menu otherwise
+# UX contract: empty input → no selection, prompt shows "[Enter=none]"
+select_multi() { ... }
+```
+
+### UX contracts the abstraction enforces
+
+- **Default surfacing**: if defaultable, prompt always reads
+  `... [N, default=K]:` (current convention from v5.4.0/v5.4.4/v5.4.6).
+- **Skip visibility**: skip path always logs via `log_info`, not
+  `log_debug` (v5.4.6 convention).
+- **Cancel path**: `Cancel` choice returns non-zero exit; caller
+  decides how to react.
+- **NONINTERACTIVE compliance**: when `NONINTERACTIVE=true`, picks
+  default + emits `log_info "Auto-selected: <label>"`.
+
+## Migration plan
+
+1. Build `select_one` + `select_multi` in `src/core/select.sh`. Source
+   from `setup.sh`. Add full bats coverage of contracts above.
+2. Migrate **group-selector.sh** (smallest, ~30 lines call site).
+3. Migrate **interactive.sh::show_category_menu + ask_tool**
+   (medium complexity — has timeout-based default).
+4. Migrate **wizard.sh::select_profile_interactive** last
+   (most behavior, profile-specific phrasing — port carefully).
+5. Delete old code, mark commits with `Closes #N` for the architectural
+   issue tracking this refactor.
+
+Each migration is its own atomic commit. The bats regression tests
+written for v5.4.0/v5.4.4/v5.4.6 stay green throughout — they're the
+guardrail. New tests cover the unified abstraction.
+
+## Why this is NOT v5.5.0
+
+- v5.5.0 scope is **skip granular** (Deney's wishlist) — that's a
+  user-visible feature with a specific request. Scoping creep would
+  delay both.
+- This refactor is **invisible to users** when correct, but user-
+  visible noise if it goes wrong (every prompt looks slightly
+  different mid-migration).
+- 2-3 days dedicated > sprinkled across releases. Refactors degrade
+  when commits are interleaved with unrelated bugfixes.
+
+## Acceptance criteria for the refactor PR
+
+- [ ] All three call sites migrated, old code deleted
+- [ ] All v5.4.0–v5.4.6 regression tests still pass
+- [ ] New contract tests for `select_one`, `select_multi` (≥10 cases)
+- [ ] `--unattended` mode never prompts (verified by integration test)
+- [ ] Docs updated: `CONTRIBUTING.md` references `select.sh` as the
+      canonical place for new prompts
+- [ ] No regression in shellcheck warnings
+- [ ] Manual validation on macOS + Linux

--- a/setup.sh
+++ b/setup.sh
@@ -326,10 +326,17 @@ main() {
         echo ""
         echo -e "${BLUE}─── Optional config layers (2 prompts, then done) ──────────────${NC}"
         echo ""
-        read -rp "[1/2] Configure dotfiles (zshrc, gitconfig, starship)? [y/N] " answer
-        if [[ "$answer" =~ ^[yYsS]$ ]]; then
-            source "${SCRIPT_DIR}/src/install/dotfiles-install.sh"
-            install_dotfiles
+        if is_section_done "dotfiles"; then
+            log_info "[1/2] Dotfiles: already done in previous run — skipping"
+            log_info "      (pick option 2 'Reinstall everything' on next run to redo)"
+        else
+            read -rp "[1/2] Configure dotfiles (zshrc, gitconfig, starship)? [y/N] " answer
+            if [[ "$answer" =~ ^[yYsS]$ ]]; then
+                source "${SCRIPT_DIR}/src/install/dotfiles-install.sh"
+                if install_dotfiles; then
+                    mark_section_done "dotfiles"
+                fi
+            fi
         fi
     fi
 
@@ -341,13 +348,20 @@ main() {
         local terminal_setup="${SCRIPT_DIR}/terminal-setup.sh"
         if [[ -x "$terminal_setup" ]]; then
             echo ""
-            read -rp "[2/2] Run terminal blueprint (Starship preset, aliases, zsh plugins)? [y/N] " answer
-            if [[ "$answer" =~ ^[yYsS]$ ]]; then
-                bash "$terminal_setup" --interactive
-                echo ""
-                echo -e "${GREEN}─── Terminal blueprint done — installer is finishing up ───${NC}"
+            if is_section_done "terminal_blueprint"; then
+                log_info "[2/2] Terminal blueprint: already done in previous run — skipping"
+                log_info "      (pick option 2 'Reinstall everything' on next run to redo)"
             else
-                log_info "Skip. Run later with: bash terminal-setup.sh --interactive"
+                read -rp "[2/2] Run terminal blueprint (Starship preset, aliases, zsh plugins)? [y/N] " answer
+                if [[ "$answer" =~ ^[yYsS]$ ]]; then
+                    if bash "$terminal_setup" --interactive; then
+                        mark_section_done "terminal_blueprint"
+                    fi
+                    echo ""
+                    echo -e "${GREEN}─── Terminal blueprint done — installer is finishing up ───${NC}"
+                else
+                    log_info "Skip. Run later with: bash terminal-setup.sh --interactive"
+                fi
             fi
         fi
     fi

--- a/src/core/progress.sh
+++ b/src/core/progress.sh
@@ -69,14 +69,108 @@ save_install_state() {
     local state_dir="${HOME}/.config/os-postinstall"
     local state_file="${state_dir}/state"
 
+    # Preserve sections_done if state file already exists (don't clobber
+    # what mark_section_done() recorded during this run).
+    local preserved_sections=""
+    if [[ -f "$state_file" ]]; then
+        preserved_sections=$(grep '^sections_done=' "$state_file" 2>/dev/null) || true
+    fi
+
     mkdir -p "$state_dir"
-    cat > "$state_file" <<EOF
-install_date=$(date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')
-profile=${profile}
-platform=${DETECTED_OS:-unknown}
-version=${SCRIPT_VERSION:-4.3}
-EOF
+    {
+        echo "install_date=$(date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')"
+        echo "profile=${profile}"
+        echo "platform=${DETECTED_OS:-unknown}"
+        echo "version=${SCRIPT_VERSION:-4.3}"
+        [[ -n "$preserved_sections" ]] && echo "$preserved_sections"
+    } > "$state_file"
     log_debug "Saved install state to ${state_file}"
+}
+
+#######################################
+# mark_section_done()
+# Record that a section completed successfully. Idempotent.
+# Args: $1 = section name (e.g., "dotfiles", "terminal_blueprint")
+# Side effect: appends to sections_done line in state file
+# Honours DRY_RUN.
+#######################################
+mark_section_done() {
+    local section="$1"
+    [[ -z "$section" ]] && return 1
+    [[ "${DRY_RUN:-}" == "true" ]] && return 0
+
+    local state_dir="${HOME}/.config/os-postinstall"
+    local state_file="${state_dir}/state"
+    mkdir -p "$state_dir"
+    [[ ! -f "$state_file" ]] && touch "$state_file"
+
+    local current_sections=""
+    if grep -q '^sections_done=' "$state_file"; then
+        current_sections=$(grep '^sections_done=' "$state_file" | cut -d= -f2-)
+    fi
+
+    case " $current_sections " in
+        *" $section "*) return 0 ;;
+    esac
+
+    local new_sections
+    new_sections=$(printf '%s %s' "$current_sections" "$section" | xargs)
+
+    local tmp_file
+    tmp_file=$(mktemp)
+    grep -v '^sections_done=' "$state_file" > "$tmp_file" 2>/dev/null || true
+    echo "sections_done=$new_sections" >> "$tmp_file"
+    mv "$tmp_file" "$state_file"
+    log_debug "Marked section done: $section"
+}
+
+#######################################
+# is_section_done()
+# Check if a section is recorded as done in state file.
+# Args: $1 = section name
+# Returns: 0 if done, 1 if not done (or no state file)
+#######################################
+is_section_done() {
+    local section="$1"
+    [[ -z "$section" ]] && return 1
+
+    local state_file="${HOME}/.config/os-postinstall/state"
+    [[ ! -f "$state_file" ]] && return 1
+
+    local sections_line
+    sections_line=$(grep '^sections_done=' "$state_file" 2>/dev/null) || return 1
+    local sections="${sections_line#sections_done=}"
+
+    case " $sections " in
+        *" $section "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+#######################################
+# list_sections_done()
+# Echo space-separated list of sections done. Empty if none.
+#######################################
+list_sections_done() {
+    local state_file="${HOME}/.config/os-postinstall/state"
+    [[ ! -f "$state_file" ]] && return 0
+    grep '^sections_done=' "$state_file" 2>/dev/null | cut -d= -f2- || true
+}
+
+#######################################
+# clear_sections_done()
+# Reset sections_done in state file (kept on "Reinstall everything" path).
+# Honours DRY_RUN.
+#######################################
+clear_sections_done() {
+    [[ "${DRY_RUN:-}" == "true" ]] && return 0
+    local state_file="${HOME}/.config/os-postinstall/state"
+    [[ ! -f "$state_file" ]] && return 0
+
+    local tmp_file
+    tmp_file=$(mktemp)
+    grep -v '^sections_done=' "$state_file" > "$tmp_file" 2>/dev/null || true
+    mv "$tmp_file" "$state_file"
 }
 
 #######################################

--- a/src/core/progress.sh
+++ b/src/core/progress.sh
@@ -185,7 +185,7 @@ detect_previous_install() {
     [[ ! -f "$state_file" ]] && return 0
 
     # Source state file to get previous values
-    local install_date="" profile="" platform="" version=""
+    local install_date="" profile="" platform="" version="" sections_done=""
     # shellcheck disable=SC1090
     source "$state_file"
 
@@ -194,20 +194,27 @@ detect_previous_install() {
     echo "  Profile:  ${profile:-unknown}"
     echo "  Platform: ${platform:-unknown}"
     echo "  Version:  ${version:-unknown}"
+    if [[ -n "$sections_done" ]]; then
+        echo "  Sections done: ${sections_done}"
+    fi
     echo ""
-    echo "  1) Update (reinstall with current profile)"
-    echo "  2) Fresh install (ignore previous state)"
-    echo "  3) Cancel"
+    echo "  1) Continue (skip sections marked done${sections_done:+: ${sections_done}})"
+    echo "  2) Reinstall everything (re-run all sections regardless of state)"
+    echo "  3) Fresh install (clear state, start over)"
+    echo "  4) Cancel"
 
     local choice
-    read -rp "Select [1-3, default=1]: " choice
+    read -rp "Select [1-4, default=1]: " choice
 
     case "$choice" in
         1) return 0 ;;
-        2) rm -f "$state_file"
+        2) clear_sections_done
+           log_info "Reinstalling everything (section state cleared)"
+           return 0 ;;
+        3) rm -f "$state_file"
            log_info "Starting fresh install"
            return 0 ;;
-        3) log_info "Cancelled by user"
+        4) log_info "Cancelled by user"
            return 1 ;;
         *) return 0 ;;
     esac

--- a/src/platforms/macos/main.sh
+++ b/src/platforms/macos/main.sh
@@ -262,9 +262,9 @@ install_profile() {
             npm-developer.txt)
                 log_debug "Skipping npm-developer.txt (handled by dev-env)"
                 ;;
-            winget.txt)
+            winget.txt|winget-developer.txt|winget-full.txt)
                 # Windows-only - skip silently on macOS
-                log_debug "Skipping winget.txt (Windows only)"
+                log_debug "Skipping $pkg_file (Windows only)"
                 ;;
             *)
                 log_warn "Unknown package file: $pkg_file"

--- a/tests/pester/winget.Tests.ps1
+++ b/tests/pester/winget.Tests.ps1
@@ -48,3 +48,57 @@ Describe '[v5.4.5] winget classifier contract' {
         $source | Should -Match 'Write-Log -Level INFO -Message "  -> \$hint"'
     }
 }
+
+# ─────────────────────────────────────────────────────────────────────
+# BEHAVIOR TEST SCAFFOLD (v5.5.0 Item 3)
+# ─────────────────────────────────────────────────────────────────────
+# These tests require:
+#   1. Windows host with winget installed
+#   2. Pester v5+
+#   3. The winget.ps1 file refactored to expose Install-WinGetPackage
+#      WITHOUT executing the main block on dot-source (currently
+#      Banner write + module imports run at script load).
+#
+# Until (3) is done, leave these as `-Skip` placeholders. Windows CI
+# runner can flip the gate to enable behavior coverage in addition to
+# the fingerprint contracts above.
+#
+# How to refactor winget.ps1 for testability:
+#   - Wrap main block in `if ($MyInvocation.InvocationName -ne '.')`
+#   - OR: split function definitions into a .psm1 module, keep .ps1
+#     as a thin runner that imports the module + calls the entry point.
+#   - The .psm1 path is preferred (matches errors.psm1, packages.psm1,
+#     logging.psm1 already in src/platforms/windows/core/).
+
+Describe '[v5.5.0] winget classifier behavior (Windows runner only)' {
+
+    BeforeAll {
+        $script:CanRun = (Get-Command winget -ErrorAction SilentlyContinue) -ne $null
+        if ($script:CanRun) {
+            # TODO: source winget.ps1 functions without triggering main block.
+            # See refactor instructions in the comment above this Describe.
+        }
+    }
+
+    It 'classifies "No package found" failure with hint' -Skip:(-not $script:CanRun) {
+        # PSEUDOCODE:
+        #   Mock winget {
+        #       $script:LASTEXITCODE = 1
+        #       'No package found matching: madeup-pkg'
+        #   } -Verifiable
+        #   Mock Test-WinGetInstalled { $false }
+        #   Mock Add-FailedItem { }
+        #   $output = Install-WinGetPackage -PackageId 'madeup-pkg' 4>&1
+        #   $output | Should -Match 'package not found in winget source'
+        #   $output | Should -Match 'winget search madeup-pkg'
+        Set-ItResult -Skipped -Because 'requires winget.ps1 refactor (see comment)'
+    }
+
+    It 'classifies "already installed" failure with reconcile hint' -Skip:(-not $script:CanRun) {
+        Set-ItResult -Skipped -Because 'requires winget.ps1 refactor (see comment)'
+    }
+
+    It 'classifies network HRESULT 0x80072... failure as network error' -Skip:(-not $script:CanRun) {
+        Set-ItResult -Skipped -Because 'requires winget.ps1 refactor (see comment)'
+    }
+}

--- a/tests/test-regressions.bats
+++ b/tests/test-regressions.bats
@@ -428,3 +428,109 @@ _run_flatpak_install_with_stderr() {
     grep -qE 'winget\.txt\|winget-developer\.txt\|winget-full\.txt' \
         "$REPO_ROOT/src/platforms/macos/main.sh"
 }
+
+# ── skip granular: section state helpers (v5.5.0) ────────────────────
+#
+# Deney's wishlist: "se ja fez partes anteriores tem que ter algo para
+# pular mais facil." Section state lets dotfiles + terminal-blueprint
+# get marked done after success, then skipped on subsequent runs.
+
+_run_section_helpers_in_tmp_home() {
+    local cmd="$1"
+    local tmp; tmp=$(mktemp -d)
+    bash -c '
+        unset _LOGGING_SOURCED _PROGRESS_SOURCED
+        export HOME="'"$tmp"'"
+        export DRY_RUN=""
+        source "'"$REPO_ROOT"'/src/core/logging.sh"
+        source "'"$REPO_ROOT"'/src/core/progress.sh"
+        '"$cmd"'
+    '
+    rm -rf "$tmp"
+}
+
+@test "[v5.5.0] mark_section_done writes section to state file" {
+    run _run_section_helpers_in_tmp_home '
+        mark_section_done "dotfiles"
+        cat "$HOME/.config/os-postinstall/state"
+    '
+    assert_success
+    assert_output --partial "sections_done=dotfiles"
+}
+
+@test "[v5.5.0] mark_section_done is idempotent (no duplicate entries)" {
+    run _run_section_helpers_in_tmp_home '
+        mark_section_done "dotfiles"
+        mark_section_done "dotfiles"
+        mark_section_done "dotfiles"
+        grep "^sections_done=" "$HOME/.config/os-postinstall/state"
+    '
+    assert_success
+    [[ "$output" == "sections_done=dotfiles" ]]
+}
+
+@test "[v5.5.0] mark_section_done appends multiple distinct sections" {
+    run _run_section_helpers_in_tmp_home '
+        mark_section_done "dotfiles"
+        mark_section_done "terminal_blueprint"
+        grep "^sections_done=" "$HOME/.config/os-postinstall/state"
+    '
+    assert_success
+    assert_output --partial "dotfiles"
+    assert_output --partial "terminal_blueprint"
+}
+
+@test "[v5.5.0] is_section_done returns 0 for marked, 1 for unmarked" {
+    run _run_section_helpers_in_tmp_home '
+        mark_section_done "dotfiles"
+        if is_section_done "dotfiles"; then echo "DOTFILES_DONE"; fi
+        if is_section_done "missing_section"; then echo "WRONG"; else echo "MISSING_NOT_DONE"; fi
+    '
+    assert_success
+    assert_output --partial "DOTFILES_DONE"
+    assert_output --partial "MISSING_NOT_DONE"
+    refute_output --partial "WRONG"
+}
+
+@test "[v5.5.0] clear_sections_done removes line but preserves metadata" {
+    run _run_section_helpers_in_tmp_home '
+        DETECTED_OS=macos save_install_state "developer"
+        mark_section_done "dotfiles"
+        clear_sections_done
+        cat "$HOME/.config/os-postinstall/state"
+    '
+    assert_success
+    assert_output --partial "profile=developer"
+    assert_output --partial "platform=macos"
+    refute_output --partial "sections_done="
+}
+
+@test "[v5.5.0] save_install_state preserves existing sections_done" {
+    # Regression: original save_install_state clobbered the whole file,
+    # so a second save (e.g., final state save at end of setup.sh) would
+    # nuke any sections_done lines mark_section_done had written.
+    run _run_section_helpers_in_tmp_home '
+        DETECTED_OS=macos save_install_state "developer"
+        mark_section_done "dotfiles"
+        DETECTED_OS=macos save_install_state "developer"
+        cat "$HOME/.config/os-postinstall/state"
+    '
+    assert_success
+    assert_output --partial "sections_done=dotfiles"
+}
+
+@test "[v5.5.0] detect_previous_install offers 4 options (Continue is new)" {
+    grep -qE '1\) Continue \(skip sections marked done' \
+        "$REPO_ROOT/src/core/progress.sh"
+    grep -qE '2\) Reinstall everything' \
+        "$REPO_ROOT/src/core/progress.sh"
+    grep -qE 'Select \[1-4, default=1\]' \
+        "$REPO_ROOT/src/core/progress.sh"
+}
+
+@test "[v5.5.0] setup.sh gates dotfiles + terminal_blueprint on is_section_done" {
+    grep -qE 'is_section_done "dotfiles"' "$REPO_ROOT/setup.sh"
+    grep -qE 'is_section_done "terminal_blueprint"' "$REPO_ROOT/setup.sh"
+    grep -qE 'mark_section_done "dotfiles"' "$REPO_ROOT/setup.sh"
+    grep -qE 'mark_section_done "terminal_blueprint"' "$REPO_ROOT/setup.sh"
+}

--- a/tests/test-regressions.bats
+++ b/tests/test-regressions.bats
@@ -416,3 +416,15 @@ _run_flatpak_install_with_stderr() {
         "$REPO_ROOT/src/platforms/linux/main.sh"
     assert_failure
 }
+
+# ── macos dispatcher: winget-*.txt symmetry (v5.4.8) ─────────────────
+
+@test "[v5.4.8] macos main.sh: all winget-*.txt files silenced as Windows-only" {
+    # Discovered by v5.4.7 dry-run audit on full profile: macos/main.sh
+    # only listed winget.txt as Windows-only; winget-developer.txt and
+    # winget-full.txt fell through to the *) catch-all and printed
+    # "WARN Unknown package file". Asymmetric with Linux which handles
+    # all brew-cask-* variants. Now all three winget files are matched.
+    grep -qE 'winget\.txt\|winget-developer\.txt\|winget-full\.txt' \
+        "$REPO_ROOT/src/platforms/macos/main.sh"
+}


### PR DESCRIPTION
## Summary

Two patches bundled in one PR (per the new admin policy in CONTRIBUTING.md, this is the first release going through PR flow instead of admin bypass).

### v5.4.8 — winget warnings on macOS
Discovered via v5.4.7 dry-run audit (`setup.sh --dry-run --unattended -y full`). macOS dispatcher emitted `WARN Unknown package file` for `winget-developer.txt` and `winget-full.txt` because the case branch only listed `winget.txt`. Now all three are silenced as Windows-only, symmetric with how Linux already handles brew-cask-* variants.

### v5.5.0 — skip granular (Deney's wishlist)
Closes "se ja fez partes anteriores tem que ter algo para pular mais facil." `setup.sh` post-install prompts (dotfiles + terminal-blueprint) are now gated on per-section state. Re-running silently skips sections that already completed.

`detect_previous_install` menu changed from 3 to 4 options:
- 1) Continue (skip done sections) — new default
- 2) Reinstall everything (clears section state)
- 3) Fresh install (deletes state file)
- 4) Cancel

MINOR bump (5.4.x → 5.5.0) because the menu shape change is user-visible.

## Atomic commits (10 total)

```
3c03cb3 fix(macos)         — silence winget-developer.txt + winget-full.txt
98fe9c8 test               — v5.4.8 regression
0752d73 chore(release)     — 5.4.8
2ce3eeb feat(state)        — section helpers (mark/is/list/clear)
19d0486 feat(progress)     — sections_done in detect_previous_install
fb46a32 feat(setup)        — gate dotfiles + terminal-blueprint
10fcbbe test               — 8 bats + 3 pester scaffolds
11abd81 docs(contributing) — admin policy: PRs over bypass
b9d1191 docs(refactor)     — selectors unification plan (v5.6.0+)
b8892b4 chore(release)     — 5.5.0
```

## Tests

Suite: 32/32 OK on `tests/test-regressions.bats` (was 24/24 before this branch).

8 new bats tests cover section helpers, state file integrity, idempotency, menu shape, setup.sh wiring. 3 Pester behavior scaffolds with Skip gate documenting the `winget.ps1 → .psm1` refactor needed for full coverage.

## Test plan

- [x] Local `bats tests/test-regressions.bats` → 32/32 OK
- [x] `bash setup.sh --dry-run --unattended -y full` → exit 0, no warnings (after fix)
- [x] `bash -n setup.sh` → syntax OK
- [ ] Manual: re-run `setup.sh` after marking dotfiles done, verify silent skip
- [ ] Windows runner: Pester `winget.Tests.ps1` (Skip gate active without refactor)

## Closes
- Wishlist Item 1 (skip granular)
- Wishlist Item 5 (E2E dry-run, found this PR's v5.4.8 fix)
- Documents Wishlist Items 2 (selectors plan) and 4 (admin PR policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)